### PR TITLE
Test only python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.9'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This is an application and not a library. There is no need to support a wide range of python versions.